### PR TITLE
Clear Cache all at once to support afterEach hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import 'givens/setup';
 or add to testing framework config, for example in jest:
 ```javascript
 {
-  setupFiles: [
+  setupFilesAfterEnv: [ // this CANNOT be setupFiles
     'givens/setup.js',
   ],
 }

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -7,7 +7,7 @@ module.exports = {
   collectCoverageFrom: [
     'dist/**/*.js',
   ],
-  setupFiles: [
+  setupFilesAfterEnv: [
     './setup.js',
   ],
 };

--- a/src/getGivenFunc.ts
+++ b/src/getGivenFunc.ts
@@ -56,10 +56,6 @@ const getGivenFunc = () => {
       }
     };
 
-    // remove cached props
-    const clearCache = () => {
-      delete cache[key];
-    };
     /* istanbul ignore next */
     if (typeof beforeAll === 'function') {
       beforeAll(push);
@@ -76,11 +72,18 @@ const getGivenFunc = () => {
     if (typeof after === 'function') {
       after(`givens teardown ${key}`, pop);
     }
-    /* istanbul ignore next */
-    if (typeof afterEach === 'function') {
-      afterEach(clearCache);
-    }
   };
+  /* istanbul ignore next */
+  if (typeof afterEach === 'function') {
+    // clear the cache after every test
+    afterEach(() => {
+      // eslint-disable-next-line no-underscore-dangle
+      const cache = (given as any).__cache__;
+      Object.keys(cache).forEach((key: any) => {
+        delete cache[key];
+      });
+    });
+  }
   return given;
 };
 

--- a/test/integration/jest/given.test.js
+++ b/test/integration/jest/given.test.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 describe('basic overriding behavior', () => {
   given('var1', () => 'initial value');
 
@@ -40,6 +42,17 @@ describe('basic caching behavior', () => {
 
     test('it caches value', () => {
       expect(given.var.value).toBe('new');
+    });
+  });
+
+  describe('with afterEach', () => {
+    afterEach(() => {
+      assert.equal(given.var.value, 'new');
+    });
+
+    test('it caches value', () => {
+      expect(given.var.value).toBe('initial');
+      given.var.value = 'new';
     });
   });
 });

--- a/test/integration/mocha/given.test.js
+++ b/test/integration/mocha/given.test.js
@@ -45,4 +45,15 @@ describe('basic caching behavior', () => {
       assert.equal(given.var.value, 'new');
     });
   });
+
+  describe('with afterEach', () => {
+    afterEach(() => {
+      assert.equal(given.var.value, 'new');
+    });
+
+    it('it caches value', () => {
+      assert.equal(given.var.value, 'initial');
+      given.var.value = 'new';
+    });
+  });
 });


### PR DESCRIPTION
by moving the `afterEach(clearCache())` logic to run on `getGiven()`, the cache will be preserved until after every other `afterEach` call has run, ensuring they have access to the cached values as well.