### PR TITLE
update and clean up linter setup

### DIFF
--- a/integration-tests/javascript/jasmine/build-givens.sh
+++ b/integration-tests/javascript/jasmine/build-givens.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+rm -rf node_modules
+rm -f givens.tgz
 cd ./../../../
 npm pack
 for f in *.tgz; do

--- a/integration-tests/javascript/jasmine/package.json
+++ b/integration-tests/javascript/jasmine/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint spec/**.*"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-jasmine": "^4.1.0",
     "givens": "file:givens.tgz",
     "jasmine": "^3.5.0"
   }

--- a/integration-tests/javascript/jasmine/spec/errors.spec.js
+++ b/integration-tests/javascript/jasmine/spec/errors.spec.js
@@ -25,7 +25,7 @@ describe('error behavior', () => {
         );
       });
 
-      it('breaks', () => {});
+      it('breaks', () => undefined);
     });
 
     describe('in afterEach method', () => {
@@ -36,7 +36,7 @@ describe('error behavior', () => {
         );
       });
 
-      it('breaks', () => {});
+      it('breaks', () => undefined);
     });
 
     describe('in beforeAll method', () => {
@@ -47,7 +47,7 @@ describe('error behavior', () => {
         );
       });
 
-      it('breaks', () => {});
+      it('breaks', () => undefined);
     });
 
     describe('in afterAll method', () => {
@@ -58,7 +58,7 @@ describe('error behavior', () => {
         );
       });
 
-      it('breaks', () => {});
+      it('breaks', () => undefined);
     });
 
     describe('in test', () => {

--- a/integration-tests/javascript/jest/build-givens.sh
+++ b/integration-tests/javascript/jest/build-givens.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+rm -rf node_modules
+rm -f givens.tgz
 cd ./../../../
 npm pack
 for f in *.tgz; do

--- a/integration-tests/javascript/jest/package.json
+++ b/integration-tests/javascript/jest/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint test/**.*"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-jest": "^23.6.0",
     "givens": "file:givens.tgz",
     "jest": "^25.1.0"
   }

--- a/integration-tests/javascript/jest/test/errors.test.js
+++ b/integration-tests/javascript/jest/test/errors.test.js
@@ -20,7 +20,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterEach method', () => {
@@ -31,7 +31,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in beforeAll method', () => {
@@ -42,7 +42,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterAll method', () => {
@@ -53,7 +53,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in test', () => {

--- a/integration-tests/javascript/mocha/build-givens.sh
+++ b/integration-tests/javascript/mocha/build-givens.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+rm -rf node_modules
+rm -f givens.tgz
 cd ./../../../
 npm pack
 for f in *.tgz; do

--- a/integration-tests/javascript/mocha/package.json
+++ b/integration-tests/javascript/mocha/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint test/**.*"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-mocha": "^6.2.2",
     "givens": "file:givens.tgz",
     "mocha": "^7.0.0"
   }

--- a/integration-tests/javascript/mocha/test/errors.test.js
+++ b/integration-tests/javascript/mocha/test/errors.test.js
@@ -7,7 +7,7 @@ describe('illegal prop', () => {
     (err) => err.message === 'givens: key "__props__" is not allowed',
   );
 
-  it('breaks', () => {});
+  it('breaks', () => undefined);
 });
 
 describe('illegal call location', () => {
@@ -19,7 +19,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterEach method', () => {
@@ -30,7 +30,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in beforeAll method', () => {
@@ -41,7 +41,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterAll method', () => {
@@ -52,7 +52,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in test', () => {

--- a/integration-tests/typescript/jest/build-givens.sh
+++ b/integration-tests/typescript/jest/build-givens.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+rm -rf node_modules
+rm -f givens.tgz
 cd ./../../../
 npm pack
 for f in *.tgz; do

--- a/integration-tests/typescript/jest/package.json
+++ b/integration-tests/typescript/jest/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint test/**.*"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.0.0",
-    "eslint-plugin-jest": "^23.6.0",
     "givens": "file:givens.tgz",
     "jest": "^25.1.0"
   }

--- a/integration-tests/typescript/jest/test/errors.test.ts
+++ b/integration-tests/typescript/jest/test/errors.test.ts
@@ -23,7 +23,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterEach method', () => {
@@ -34,7 +34,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in beforeAll method', () => {
@@ -45,7 +45,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in afterAll method', () => {
@@ -56,7 +56,7 @@ describe('illegal call location', () => {
       );
     });
 
-    it('breaks', () => {});
+    it('breaks', () => undefined);
   });
 
   describe('in test', () => {

--- a/integration-tests/typescript/jest/test/given-typed.test.ts
+++ b/integration-tests/typescript/jest/test/given-typed.test.ts
@@ -1,14 +1,14 @@
 import assert from 'assert';
 import getGiven from 'givens';
 
-interface myVars {
+interface MyVars {
   var1: string;
   var2: string;
   var: { value: string };
   random: number;
 }
 
-const given = getGiven<myVars>();
+const given = getGiven<MyVars>();
 
 describe('basic overriding behavior', () => {
   given('var1', () => 'initial value');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1734,12 +1734,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "confusing-browser-globals": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
-      "dev": true
-    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -2094,39 +2088,6 @@
         }
       }
     },
-    "eslint-config-airbnb": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.1.0.tgz",
-      "integrity": "sha512-kZFuQC/MPnH7KJp6v95xsLBf63G/w7YqdPfQ0MUanxQ7zcKUNG8j+sSY860g3NwCBOa62apw16J6pRN+AOgXzw==",
-      "dev": true,
-      "requires": {
-        "eslint-config-airbnb-base": "^14.1.0",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1"
-      }
-    },
-    "eslint-config-airbnb-base": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
-      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
-      "dev": true,
-      "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1"
-      }
-    },
-    "eslint-config-airbnb-typescript": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-7.2.0.tgz",
-      "integrity": "sha512-W7IZUIJpBZIzU3p65KoyJPl2vGSy6FS3R+K91Cp3NLK/0m1oyvCFeBHI2QlWdqxkJ4FvwnLvsoRTutwpKNIT+A==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/parser": "^2.24.0",
-        "eslint-config-airbnb": "^18.1.0",
-        "eslint-config-airbnb-base": "^14.1.0"
-      }
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -2380,6 +2341,12 @@
         }
       }
     },
+    "eslint-plugin-jasmine": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.0.tgz",
+      "integrity": "sha512-Vfuk2Sm1ULR7MqGjVIOOEdQWyoFBfSwvwUeo9MrajVGJB3C24c9Mmj1Cgf8Qwmf3aS2bezPt1sckpKXWpd74Dw==",
+      "dev": true
+    },
     "eslint-plugin-jest": {
       "version": "23.8.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz",
@@ -2387,6 +2354,15 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^2.5.0"
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-4.12.1.tgz",
+      "integrity": "sha512-hxWtYHvLA0p/PKymRfDYh9Mxt5dYkg2Goy1vZDarTEEYfELP9ksga7kKG1NUKSQy27C8Qjc7YrSWTLUhOEOksA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.25.0"
       }
     },
     "eslint-scope": {
@@ -5373,18 +5349,6 @@
         "object-keys": "^1.0.11"
       }
     },
-    "object.entries": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
@@ -5737,6 +5701,12 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
       "dev": true
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "copy-dts": "copyfiles -u 1 \"src/getGiven.d.ts\" dist",
     "lint": "npm-run-all --continue-on-error lint:**",
     "lint:main": "eslint ./src/**.* ./test/**.* --ext .ts",
-    "lint:js-jest": "cd integration-tests/javascript/jest && npm run lint",
-    "lint:js-mocha": "cd integration-tests/javascript/mocha && npm run lint",
-    "lint:js-jasmine": "cd integration-tests/javascript/jasmine && npm run lint",
-    "lint:ts-jest": "cd integration-tests/typescript/jest && npm run lint",
+    "lint:js-jest": "eslint ./integration-tests/javascript/jest/test/**.* --ext .js",
+    "lint:js-mocha": "eslint ./integration-tests/javascript/mocha/test/**.* --ext .js",
+    "lint:js-jasmine": "eslint ./integration-tests/javascript/jasmine/spec/**.* --ext .js",
+    "lint:ts-jest": "eslint ./integration-tests/typescript/jest/test/**.* --ext .ts",
     "test": "npm-run-all --continue-on-error test:**",
     "test:unit": "jest",
     "test:js-jest": "cd integration-tests/javascript/jest && npm test",
@@ -55,10 +55,10 @@
     "@typescript-eslint/parser": "^2.24.0",
     "copyfiles": "^2.2.0",
     "eslint": "^6.8.0",
-    "eslint-config-airbnb-base": "^14.1.0",
-    "eslint-config-airbnb-typescript": "^7.2.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jest": "^23.8.2",
+    "eslint-plugin-jasmine": "^4.1.0",
+    "eslint-plugin-mocha": "^4.1.0",
     "jest": "^25.1.0",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^25.2.1",
@@ -71,10 +71,13 @@
       "@typescript-eslint"
     ],
     "extends": [
-      "airbnb-typescript/base"
+      "plugin:@typescript-eslint/recommended"
     ],
     "rules": {
-      "no-underscore-dangle": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/no-var-requires": "off"
     }
   }
 }

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-param-reassign */
-
 import {
   givenCache,
   givenProps,

--- a/src/getContextInfo.ts
+++ b/src/getContextInfo.ts
@@ -9,9 +9,9 @@ interface DisallowedContextInfo {
   allowed: false;
   message: string;
 }
-type contextInfo = AllowedContextInfo | DisallowedContextInfo;
+type ContextInfo = AllowedContextInfo | DisallowedContextInfo;
 
-function jestContextMatcher(rawStack: string): contextInfo | undefined {
+function jestContextMatcher(rawStack: string): ContextInfo | undefined {
   if (/Object\.asyncJestLifecycle/.test(rawStack)) {
     return {
       allowed: false,
@@ -33,7 +33,7 @@ function jestContextMatcher(rawStack: string): contextInfo | undefined {
 }
 
 /* istanbul ignore next */
-function mochaContextMatcher(rawStack: string): contextInfo | undefined {
+function mochaContextMatcher(rawStack: string): ContextInfo | undefined {
   if (/Test\.Runnable\.run/.test(rawStack)) {
     return {
       allowed: false,
@@ -53,7 +53,7 @@ function mochaContextMatcher(rawStack: string): contextInfo | undefined {
 }
 
 /* istanbul ignore next */
-function jasmineContextMatcher(rawStack: string): contextInfo | undefined {
+function jasmineContextMatcher(rawStack: string): ContextInfo | undefined {
   if (/jasmine\.js/.test(rawStack)) {
     if (!/Env\.describe/.test(rawStack)) {
       return {
@@ -66,7 +66,7 @@ function jasmineContextMatcher(rawStack: string): contextInfo | undefined {
   return undefined;
 }
 
-export default function getContextInfo(ssf: Function): contextInfo {
+export default function getContextInfo(ssf: Function): ContextInfo {
   let rawStack: string;
   try {
     const err = new Error();
@@ -78,7 +78,7 @@ export default function getContextInfo(ssf: Function): contextInfo {
   } catch (e) {
     rawStack = e.stack;
   }
-  let context: contextInfo | undefined;
+  let context: ContextInfo | undefined;
   context = jestContextMatcher(rawStack);
 
   /* istanbul ignore else */

--- a/src/getGiven.d.ts
+++ b/src/getGiven.d.ts
@@ -1,5 +1,6 @@
+/* eslint-disable-next-line @typescript-eslint/class-name-casing */
 interface givenFunc<T> {
-  <K extends keyof T>(key: K, func: () => T[K]): void
+  <K extends keyof T>(key: K, func: () => T[K]): void;
 }
 
 type given<T> = givenFunc<T> & T;

--- a/src/isValid.ts
+++ b/src/isValid.ts
@@ -1,7 +1,3 @@
-interface parsedKey {
-  valid: boolean;
-  errorMessage?: string;
-}
 
 function allProps(object: any): string[] {
   const myProps = Object.getOwnPropertyNames(object);
@@ -18,7 +14,7 @@ const disallowedProps = [
   // prototype props
   ...allProps(
     /* istanbul ignore next */
-    () => {},
+    () => undefined,
   ),
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,9 @@ export type givenCache<T> = Partial<T>;
 
 export type givenTrace<T> = (keyof T)[];
 
+/* eslint-disable-next-line @typescript-eslint/class-name-casing */
 export interface givenFunc<T> {
-  <K extends keyof T>(key: K, func: () => T[K]): void
+  <K extends keyof T>(key: K, func: () => T[K]): void;
 }
 
 export type given<T> = givenFunc<T> & T;

--- a/test/evaluate.spec.ts
+++ b/test/evaluate.spec.ts
@@ -12,16 +12,16 @@ mockedGivenError.mockImplementation(
   (message: string) => (new Error(message) as unknown as typeof GivenError),
 );
 
-interface testType {
+interface TestType {
   key1: string;
   key2: string;
   key3: string;
 }
 
 let key: any;
-let props: givenProps<testType>;
-let cache: givenCache<testType>;
-let trace: givenTrace<testType>;
+let props: givenProps<TestType>;
+let cache: givenCache<TestType>;
+let trace: givenTrace<TestType>;
 let ssi: Function;
 
 beforeEach(() => {
@@ -38,21 +38,21 @@ beforeEach(() => {
 
 describe('evaluate', () => {
   it('uses the top props', () => {
-    expect(evaluate<testType, 'key1'>(key, props, cache, trace, ssi)).toBe('key1 value2');
+    expect(evaluate<TestType, 'key1'>(key, props, cache, trace, ssi)).toBe('key1 value2');
   });
 
   describe('trace detection', () => {
     it('throws the correct error', () => {
       trace = ['key1'];
       const f = () => {
-        evaluate<testType, 'key1'>(key, props, cache, trace, ssi);
+        evaluate<TestType, 'key1'>(key, props, cache, trace, ssi);
       };
       expect(f).toThrowErrorMatchingSnapshot();
     });
     it('shows the correct sequence', () => {
       trace = ['key2', 'key1', 'key3'];
       const f = () => {
-        evaluate<testType, 'key1'>(key, props, cache, trace, ssi);
+        evaluate<TestType, 'key1'>(key, props, cache, trace, ssi);
       };
       expect(f).toThrowErrorMatchingSnapshot();
     });
@@ -61,7 +61,7 @@ describe('evaluate', () => {
   describe('error catching', () => {
     it('throws error', () => {
       props.key1 = [() => { throw new Error('error'); }];
-      expect(() => evaluate<testType, 'key1'>(key, props, cache, trace, ssi)).toThrowError('error');
+      expect(() => evaluate<TestType, 'key1'>(key, props, cache, trace, ssi)).toThrowError('error');
     });
 
     it('resets trace', () => {
@@ -69,7 +69,7 @@ describe('evaluate', () => {
         throw new Error('error');
       }];
       trace = ['key3'];
-      expect(() => evaluate<testType, 'key1'>(key, props, cache, trace, ssi)).toThrowError('error');
+      expect(() => evaluate<TestType, 'key1'>(key, props, cache, trace, ssi)).toThrowError('error');
       expect(trace).toHaveLength(0);
     });
   });
@@ -79,7 +79,7 @@ describe('evaluate', () => {
       const topFn = jest.fn(() => 'value1');
       props.key1 = [topFn];
       cache.key1 = 'cachedValue';
-      expect(evaluate<testType, 'key1'>(key, props, cache, trace, ssi)).toBe('cachedValue');
+      expect(evaluate<TestType, 'key1'>(key, props, cache, trace, ssi)).toBe('cachedValue');
       expect(topFn).not.toHaveBeenCalled();
     });
   });

--- a/test/getContextInfo.spec.ts
+++ b/test/getContextInfo.spec.ts
@@ -8,6 +8,7 @@ function exampleFn() {
 
 // we need to use node's assert to test the interactions with jest
 // this is unfortunately unavoidable to test this behavior
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const assert = require('assert');
 
 assert.equal(exampleFn().allowed, true);

--- a/test/getGiven.spec.ts
+++ b/test/getGiven.spec.ts
@@ -8,7 +8,7 @@ jest.unmock('../src/getGiven');
 
 describe('getGiven', () => {
   const myGiven = getGiven<any>();
-  myGiven('key', () => {});
+  myGiven('key', () => undefined);
 
   it('passes getGivenFunc through', () => {
     expect(originalFunc).toHaveBeenCalled();

--- a/test/getGivenFunc.spec.ts
+++ b/test/getGivenFunc.spec.ts
@@ -41,12 +41,12 @@ describe('getGivenFunc', () => {
   });
 
   describe('given function', () => {
-    interface test {
-      key1: string,
-      key2: string,
-      key3: string,
+    interface Test {
+      key1: string;
+      key2: string;
+      key3: string;
     }
-    const given = getGiven<test>();
+    const given = getGiven<Test>();
 
     it('calls beforeAll', () => {
       given('key1', () => 'value1');

--- a/test/givenError.spec.ts
+++ b/test/givenError.spec.ts
@@ -4,7 +4,7 @@ jest.unmock('../src/givenError');
 
 describe('GivenError', () => {
   it('appends "givens: " to the beginning of the message', () => {
-    const err = new GivenError('message', () => {});
+    const err = new GivenError('message', () => undefined);
     expect(err.message).toEqual('givens: message');
   });
 


### PR DESCRIPTION
Moved all the lifting logic from individual integration tests to root.

fixed issue causing integration tests to not reload the package.

switched to a less feature-full eslint base as the airbnb typescript one was broken with the weird multi project nature of this package